### PR TITLE
Save Rout.fail files in tests/ as well as subdirectories

### DIFF
--- a/templates/job-linux.xml
+++ b/templates/job-linux.xml
@@ -73,7 +73,7 @@
               <transfers>
                 <jenkins.plugins.publish__over__ssh.BapSshTransfer>
                   <remoteDirectory>${JOB_BASE_NAME}</remoteDirectory>
-                  <sourceFiles>${JOB_BASE_NAME}/**/00install.out,${JOB_BASE_NAME}/**/00check.log,${JOB_BASE_NAME}/**/tests/*.Rout,${JOB_BASE_NAME}/*.tar.gz</sourceFiles>
+                  <sourceFiles>${JOB_BASE_NAME}/**/00install.out,${JOB_BASE_NAME}/**/00check.log,${JOB_BASE_NAME}/**/tests/**/*.Rout*,${JOB_BASE_NAME}/*.tar.gz</sourceFiles>
                   <excludes></excludes>
                   <removePrefix>${JOB_BASE_NAME}/</removePrefix>
                   <remoteDirectorySDF>false</remoteDirectorySDF>

--- a/templates/job-windows.xml
+++ b/templates/job-windows.xml
@@ -78,7 +78,7 @@
               <transfers>
                 <jenkins.plugins.publish__over__ssh.BapSshTransfer>
                   <remoteDirectory>${JOB_BASE_NAME}</remoteDirectory>
-                  <sourceFiles>${JOB_BASE_NAME}/**/00install.out,${JOB_BASE_NAME}/**/00check.log,${JOB_BASE_NAME}/**/tests/*.Rout,${JOB_BASE_NAME}/*.zip</sourceFiles>
+                  <sourceFiles>${JOB_BASE_NAME}/**/00install.out,${JOB_BASE_NAME}/**/00check.log,${JOB_BASE_NAME}/**/tests/**/*.Rout*,${JOB_BASE_NAME}/*.zip</sourceFiles>
                   <excludes></excludes>
                   <removePrefix>${JOB_BASE_NAME}/</removePrefix>
                   <remoteDirectorySDF>false</remoteDirectorySDF>


### PR DESCRIPTION
Especially when using testthat the errors will be typically be in
pkgname.Rcheck/tests/testthat.Rout.fail, which is currently not saved by
Rhub